### PR TITLE
Stringify the data from the library itself

### DIFF
--- a/ajax.js
+++ b/ajax.js
@@ -16,7 +16,7 @@ var ajax = function(definedOptions, cb) {
 		if (!definedOptions.hasOwnProperty("url")) throw "Missing required option: url";
 
 		var options = {
-			"method": (definedOptions.method || "GET"),
+			"method": (JSON.stringify(definedOptions.method) || "GET"),
 			"url": definedOptions.url,
 			"data": (definedOptions.data || null),
 			"headers": (definedOptions.headers || {})

--- a/ajax.js
+++ b/ajax.js
@@ -16,9 +16,9 @@ var ajax = function(definedOptions, cb) {
 		if (!definedOptions.hasOwnProperty("url")) throw "Missing required option: url";
 
 		var options = {
-			"method": (JSON.stringify(definedOptions.method) || "GET"),
+			"method": (definedOptions.method || "GET"),
 			"url": definedOptions.url,
-			"data": (definedOptions.data || null),
+			"data": (JSON.stringify(definedOptions.data) || null),
 			"headers": (definedOptions.headers || {})
 		};
 


### PR DESCRIPTION
This will help the user send any kind of data and focus of development and will avoid the user trivial issues when debugging instead of checking everytime if he/she used `JSON.stringify()` or not